### PR TITLE
Get rid of an initialization parameter on Android

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.livebundle">
     <application>
-       <activity android:name=".LiveBundleActivity" android:exported="true">
+       <activity android:name="com.livebundle.LiveBundleActivity" android:exported="true">
             <intent-filter android:label="LBIntentDL">
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT" />

--- a/example/App.js
+++ b/example/App.js
@@ -10,9 +10,7 @@ export default class App extends Component<{}> {
   render() {
     return (
       <View style={styles.container}>
-        <Text style={styles.welcome}>{`LiveBundle Demo [${
-          __DEV__ ? 'dev' : 'prod'
-        }]`}</Text>
+        <Text style={styles.welcome}>LiveBundle Demo</Text>
         <TouchableOpacity
           style={styles.button}
           onPress={() => livebundle.launchUI()}>

--- a/example/android/app/src/main/java/com/example/MainApplication.java
+++ b/example/android/app/src/main/java/com/example/MainApplication.java
@@ -48,7 +48,6 @@ public class MainApplication extends Application implements ReactApplication {
     SoLoader.init(this, /* native exopackage */ false);
     LiveBundleModule.initialize(
       getReactNativeHost().getReactInstanceManager(),
-      MainActivity.class,
       "https://02513afc7fstg.blob.core.windows.net/demo/",
       "?sv=2019-10-10&si=read&sr=c&sig=fr91iHiQa0EDcAVAw1hn%2B%2FZPsJiPZ84c8sd%2BlGA1gV0%3D");
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());


### PR DESCRIPTION
Get rid of `mainActivityClass` parameter in Android `initialize` method of `LiveBundleModule`.
This parameter was a hacky way to get the Activity to launch *(mostly for after navigating a deep link from cold app state)*.
This PR now resort on a more proper standard way to get an intent to launch the 'main' Activity, by relying on [`PackageManager.getLaunchIntentForPackage`](https://developer.android.com/reference/android/content/pm/PackageManager#getLaunchIntentForPackage(java.lang.String)) method.
This makes it easier to initialize LiveBundle on the client side, as it is not necessary to get a hold on the main Activity class which can be tricky in some situations, heavily based on the application architecture.