### PR TITLE
Add deeplink to LiveBundle menu

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="livebundle" android:host="menu" />
                 <data android:scheme="livebundle" android:host="packages" />
                 <data android:scheme="livebundle" android:host="sessions" />
             </intent-filter>

--- a/android/src/main/java/io/livebundle/LiveBundleActivity.java
+++ b/android/src/main/java/io/livebundle/LiveBundleActivity.java
@@ -40,6 +40,8 @@ public class LiveBundleActivity extends ReactActivity {
         } else if (authority.equals("sessions")) {
           Log.d(TAG, "onCreate() sessions deeplink");
           this.mDeppLinkLiveSessionId = uri.getQueryParameter("id");
+        } else if (authority.equals("menu")) {
+          Log.d(TAG, "onCreate() menu deeplink");
         }
       } catch (Exception e) {
       }


### PR DESCRIPTION
Add a deeplink _(`livebundle://menu`)_ to launch LiveBundle menu Activity
This can be helpful in some situations