### PR TITLE
Update Android module initialization

### DIFF
--- a/android/src/main/java/io/livebundle/LiveBundleActivity.java
+++ b/android/src/main/java/io/livebundle/LiveBundleActivity.java
@@ -9,6 +9,7 @@ import androidx.annotation.Nullable;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactNativeHost;
 
 public class LiveBundleActivity extends ReactActivity {
   private String mDeepLinkPackageId;
@@ -51,6 +52,11 @@ public class LiveBundleActivity extends ReactActivity {
   protected ReactActivityDelegate createReactActivityDelegate() {
     Log.d(TAG, "createReactActivityDelegate()");
     return new ReactActivityDelegate(this, getMainComponentName()) {
+      @Override
+      protected ReactNativeHost getReactNativeHost() {
+        return LiveBundleModule.getReactNativeHost();
+      }
+
       @Nullable
       @Override
       protected Bundle getLaunchOptions() {

--- a/android/src/main/java/io/livebundle/LiveBundleModule.java
+++ b/android/src/main/java/io/livebundle/LiveBundleModule.java
@@ -8,6 +8,7 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.WritableMap;
@@ -64,6 +65,8 @@ public class LiveBundleModule extends ReactContextBaseJavaModule {
   private static ReactInstanceManager sReactInstanceManager;
   private static String sAzureSasToken;
   private static String sAzureUrl;
+  private static ReactNativeHost sReactNativeHost;
+
   private final File mJSLiveBundleFile;
   private final File mJSLiveBundleZipFile;
 
@@ -151,17 +154,22 @@ public class LiveBundleModule extends ReactContextBaseJavaModule {
    * Initialize LiveBundle
    * Should be called by client application during application start
    *
-   * @param manager           ReactInstanceManager instance
+   * @param reactNativeHost   Instance of ReactNativeHost to use
    * @param azureUrl          Azure URL
    * @param azureSasToken     Azure SAS token (reads)
    */
   public static void initialize(
-    ReactInstanceManager manager,
+    ReactNativeHost reactNativeHost,
     String azureUrl,
     String azureSasToken) {
-    LiveBundleModule.sReactInstanceManager = manager;
+    LiveBundleModule.sReactNativeHost = reactNativeHost;
+    LiveBundleModule.sReactInstanceManager = reactNativeHost.getReactInstanceManager();
     LiveBundleModule.sAzureUrl = azureUrl;
     LiveBundleModule.sAzureSasToken = azureSasToken;
+  }
+
+  public static ReactNativeHost getReactNativeHost() {
+    return LiveBundleModule.sReactNativeHost;
   }
 
   /**

--- a/example/android/app/src/main/java/com/example/MainApplication.java
+++ b/example/android/app/src/main/java/com/example/MainApplication.java
@@ -47,7 +47,7 @@ public class MainApplication extends Application implements ReactApplication {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
     LiveBundleModule.initialize(
-      getReactNativeHost().getReactInstanceManager(),
+      getReactNativeHost(),
       "https://02513afc7fstg.blob.core.windows.net/demo/",
       "?sv=2019-10-10&si=read&sr=c&sig=fr91iHiQa0EDcAVAw1hn%2B%2FZPsJiPZ84c8sd%2BlGA1gV0%3D");
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());


### PR DESCRIPTION
Require client to provide the instance of `ReactNativeHost` to use, instead of the `ReactInstanceManager` instance, as it gives more flexibility to adapt to different client application architectures.