### PR TITLE
Rename some props

### DIFF
--- a/LiveBundleUI.js
+++ b/LiveBundleUI.js
@@ -20,9 +20,9 @@ export class LiveBundleUI extends Component<{}> {
       isDownloadCompleted: false,
       isScanCompleted: false,
       isScanInitiated: false,
-      packageId: props && props.deepLinkPackageId,
+      packageId: props && props.packageId,
       packageMetadata: undefined,
-      sessionId: props && props.deepLinkSessionId,
+      sessionId: props && props.sessionId,
       error: undefined,
     };
   }

--- a/android/src/main/java/io/livebundle/LiveBundleActivity.java
+++ b/android/src/main/java/io/livebundle/LiveBundleActivity.java
@@ -69,7 +69,7 @@ public class LiveBundleActivity extends ReactActivity {
         if (LiveBundleActivity.this.mDeepLinkPackageId != null) {
           Log.d(TAG, "getLaunchOptions() deepLinkPackageId");
           Bundle bundle = new Bundle();
-          bundle.putString("deepLinkPackageId", LiveBundleActivity.this.mDeepLinkPackageId);
+          bundle.putString("packageId", LiveBundleActivity.this.mDeepLinkPackageId);
           return bundle;
         }
         //
@@ -78,7 +78,7 @@ public class LiveBundleActivity extends ReactActivity {
         else if (LiveBundleActivity.this.mDeppLinkLiveSessionId != null) {
           Log.d(TAG, "getLaunchOptions() deepLinkSessionId");
           Bundle bundle = new Bundle();
-          bundle.putString("deepLinkSessionId", LiveBundleActivity.this.mDeppLinkLiveSessionId);
+          bundle.putString("sessionId", LiveBundleActivity.this.mDeppLinkLiveSessionId);
           return bundle;
         }
         Log.d(TAG, "getLaunchOptions() null");


### PR DESCRIPTION
`deepLinkPackageId` => `packageId`
`deepLinkSessionId` => `sessionId`

**Why ?**

- To make it on par with state property names
- Because a packageId/sessionId is still a packageId/sessionId (and handled the same) whether it comes from a deep link or not _(the activity might well be launched with a packageId and/or sessionId that are not coming from a deep link)._