### PR TITLE
Fix a bug when no url suffix is used

### DIFF
--- a/LiveBundle.js
+++ b/LiveBundle.js
@@ -38,7 +38,7 @@ export class LiveBundle {
    * @param {string} resourcePath Path to resource
    */
   getUrl(resourcePath) {
-    return `${this.STORAGE_URL_PREFIX}${resourcePath}${this.STORAGE_URL_SUFFIX}`;
+    return `${this.STORAGE_URL_PREFIX}${resourcePath}${this.STORAGE_URL_SUFFIX ?? ""}`;
   }
 
   /**

--- a/android/src/main/java/io/livebundle/LiveBundle.java
+++ b/android/src/main/java/io/livebundle/LiveBundle.java
@@ -69,7 +69,7 @@ public class LiveBundle extends ReactContextBaseJavaModule {
   private static boolean sBundleInstalled = false;
   private static boolean sSessionStarted = false;
   private static ReactInstanceManager sReactInstanceManager;
-  private static String sStorageUrlSuffix = "";
+  private static String sStorageUrlSuffix;
   private static String sStorageUrlPrefix;
   private static ReactNativeHost sReactNativeHost;
 
@@ -375,7 +375,11 @@ public class LiveBundle extends ReactContextBaseJavaModule {
         }
       },
       mJSLiveBundleZipFile,
-      String.format("%spackages/%s/%s%s", sStorageUrlPrefix, packageId, bundleId, sStorageUrlSuffix),
+      String.format("%spackages/%s/%s%s",
+        sStorageUrlPrefix,
+        packageId,
+        bundleId,
+        sStorageUrlSuffix == null ? "" : sStorageUrlSuffix),
       bundleInfo);
   }
 


### PR DESCRIPTION
When `LiveBundle.initialize` method is called with a null `storageUrlSuffix` parameter it results in invalid urls with a `null` suffix, for example:

`/packages/08ce52c3-fa37-48a3-abe3-a56ebb828606/metadata.jsonnull`

This PR fixes this bug.