### PR TITLE
Trim trailing slash from url

### DIFF
--- a/LiveBundle.js
+++ b/LiveBundle.js
@@ -38,7 +38,7 @@ export class LiveBundle {
    * @param {string} resourcePath Path to resource
    */
   getUrl(resourcePath) {
-    return `${this.STORAGE_URL}${resourcePath}${this.STORAGE_URL_SUFFIX ?? ""}`;
+    return `${this.STORAGE_URL}/${resourcePath}${this.STORAGE_URL_SUFFIX ?? ""}`;
   }
 
   /**

--- a/android/src/main/java/io/livebundle/LiveBundle.java
+++ b/android/src/main/java/io/livebundle/LiveBundle.java
@@ -176,7 +176,7 @@ public class LiveBundle extends ReactContextBaseJavaModule {
     @Nullable String storageUrlSuffix) {
     LiveBundle.sReactNativeHost = reactNativeHost;
     LiveBundle.sReactInstanceManager = reactNativeHost.getReactInstanceManager();
-    LiveBundle.sStorageUrl = storageUrl;
+    LiveBundle.sStorageUrl = storageUrl.replaceAll("/$", "");
     if (sStorageUrlSuffix != null) {
       LiveBundle.sStorageUrlSuffix = storageUrlSuffix;
     }
@@ -375,7 +375,7 @@ public class LiveBundle extends ReactContextBaseJavaModule {
         }
       },
       mJSLiveBundleZipFile,
-      String.format("%spackages/%s/%s%s",
+      String.format("%s/packages/%s/%s%s",
         storageUrl,
         packageId,
         bundleId,

--- a/example/android/app/src/main/java/com/example/MainApplication.java
+++ b/example/android/app/src/main/java/com/example/MainApplication.java
@@ -48,7 +48,7 @@ public class MainApplication extends Application implements ReactApplication {
     SoLoader.init(this, /* native exopackage */ false);
     LiveBundle.initialize(
       getReactNativeHost(),
-      "https://02513afc7fstg.blob.core.windows.net/demo/",
+      "https://02513afc7fstg.blob.core.windows.net/demo",
       "?sv=2019-10-10&si=read&sr=c&sig=fr91iHiQa0EDcAVAw1hn%2B%2FZPsJiPZ84c8sd%2BlGA1gV0%3D");
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
   }


### PR DESCRIPTION
To make the url string templates more readable, don't use a trailing slash in user provided storage url.
If a trailing slash is found, remove it in `initialize` method.