### PR TITLE
Update example application to use local http server

### DIFF
--- a/example/android/app/src/main/java/com/example/MainApplication.java
+++ b/example/android/app/src/main/java/com/example/MainApplication.java
@@ -48,8 +48,8 @@ public class MainApplication extends Application implements ReactApplication {
     SoLoader.init(this, /* native exopackage */ false);
     LiveBundle.initialize(
       getReactNativeHost(),
-      "https://02513afc7fstg.blob.core.windows.net/demo",
-      "?sv=2019-10-10&si=read&sr=c&sig=fr91iHiQa0EDcAVAw1hn%2B%2FZPsJiPZ84c8sd%2BlGA1gV0%3D");
+      "http://127.0.0.1:8080",
+      null);
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
   }
 

--- a/example/livebundle.yaml
+++ b/example/livebundle.yaml
@@ -8,9 +8,8 @@ bundler:
 
 # Storage
 storage:
-  azure:
-    accountUrl: https://02513afc7fstg.blob.core.windows.net
-    container: demo
+  fs:
+    storageDir: ~/.livebundle/storage
 
 # Generators
 generators:


### PR DESCRIPTION
We can rely on `fs-storage` plugin to use a local directory as LiveBundle storage and easily spin up a local http server from this directory to act as a static file server. This is great because it means that anyone can try out the example application _(and implicitly LiveBundle)_ without having to rely on the availability of an Azure Blob Storage account.

Will update documentation accordingly.
