### PR TITLE
Generate ios dev bundle for example app

### DIFF
--- a/example/livebundle.yaml
+++ b/example/livebundle.yaml
@@ -5,6 +5,9 @@ bundler:
       - dev: true
         entry: index.js
         platform: android
+      - dev: true
+        entry: index.js
+        platform: ios
 
 # Storage
 storage:


### PR DESCRIPTION
Update example application `livebundle.yml` configuration to generate and iOS dev bundle in addition to the Android one