### PR TITLE
Cleanup livebundle config of example app

### DIFF
--- a/example/livebundle.yml
+++ b/example/livebundle.yml
@@ -1,13 +1,6 @@
 # JavaScript bundler
 bundler:
   metro:
-    bundles:
-      - dev: true
-        entry: index.js
-        platform: android
-      - dev: true
-        entry: index.js
-        platform: ios
 
 # Storage
 storage:


### PR DESCRIPTION
The config does not need to explicitly set the bundles to generate in the bundler configuration, as it is already [the default CLI inherited configuration](https://github.com/electrode-io/livebundle/blob/master/packages/livebundle/config/default.yaml#L15-L22)