### PR TITLE
Add iOS Deep Link support

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -244,7 +244,7 @@ PODS:
     - React
   - react-native-camera/RN (3.37.0):
     - React
-  - react-native-livebundle (0.0.5):
+  - react-native-livebundle (0.0.8):
     - React
   - React-RCTActionSheet (0.63.2):
     - React-Core/RCTActionSheetHeaders (= 0.63.2)
@@ -465,7 +465,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 8ca588cc921e70590820ce72b8789b02c67cce38
   React-jsinspector: b14e62ebe7a66e9231e9581279909f2fc3db6606
   react-native-camera: 584d595599f45ba537e2c6fca05fb7173ccfaf59
-  react-native-livebundle: 005af569b0e956ea1ff4410c83ee1029b8317af3
+  react-native-livebundle: 8b68fa80cd948c997b0251ab005d392a6654f2ff
   React-RCTActionSheet: 910163b6b09685a35c4ebbc52b66d1bfbbe39fc5
   React-RCTAnimation: 9a883bbe1e9d2e158d4fb53765ed64c8dc2200c6
   React-RCTBlob: 39cf0ece1927996c4466510e25d2105f67010e13
@@ -482,4 +482,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 526a779afcbde7de5cd1dac79f81b88960451305
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.9.3

--- a/example/ios/example/AppDelegate.m
+++ b/example/ios/example/AppDelegate.m
@@ -49,12 +49,12 @@ static void InitializeFlipper(UIApplication *application) {
   return YES;
 }
 
-//- (BOOL)application:(UIApplication *)application
-//   openURL:(NSURL *)url
-//   options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
-//{
-//  return [RCTLinkingManager application:application openURL:url options:options];
-//}
+- (BOOL)application:(UIApplication *)application
+   openURL:(NSURL *)url
+   options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+  return [RCTLinkingManager application:application openURL:url options:options];
+}
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {

--- a/example/ios/example/Info.plist
+++ b/example/ios/example/Info.plist
@@ -60,7 +60,7 @@
 			<string>com.walmart.electrodenative</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>example</string>
+				<string>livebundle</string>
 			</array>
 		</dict>
 	</array>

--- a/ios/LiveBundle.m
+++ b/ios/LiveBundle.m
@@ -62,7 +62,7 @@ RCT_EXPORT_METHOD(getState:(RCTPromiseResolveBlock)resolve reject:(__unused RCTP
     resolve(@[state]);
 }
 
-RCT_EXPORT_METHOD(launchUI:(RCTPromiseResolveBlock)resolve reject:(__unused RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(launchUI:(NSDictionary *)props resolve:(RCTPromiseResolveBlock)resolve reject:(__unused RCTPromiseRejectBlock)reject) {
     dispatch_async(dispatch_get_main_queue(), ^{
         if (![jsPath  isEqual: @""]) {
         NSURL *bundleURL = [[NSURL alloc] initFileURLWithPath:jsPath];
@@ -70,7 +70,7 @@ RCT_EXPORT_METHOD(launchUI:(RCTPromiseResolveBlock)resolve reject:(__unused RCTP
     }
         RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:self->_bridge
                                                          moduleName:@"LiveBundleUI"
-                                                  initialProperties:nil];
+                                                  initialProperties:props];
         UIViewController * vc = [[UIViewController alloc] init];
         vc.view = rootView;
         [self->_rootVC pushViewController:vc animated:true];


### PR DESCRIPTION
Handle Deep Links from the JS side using [Linking core native module](https://reactnative.dev/docs/linking).
Support for `livebundle://packages`, `livebundle://sessions` and `livebundle://menu`
Will look into refactoring Android current implementation to use same logic _(will avoid having to maintain an Android native implementation separate from iOS and will be able to remove platform specific switches in the JS native module code)_