### PR TITLE
Fix exo bundling for iOS release builds

### DIFF
--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -373,7 +373,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
+			shellScript = "cd ${SRCROOT}/../\nexport NODE_BINARY=node\nnode_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
 		2D02E4CB1E0B4B27006451C7 /* Bundle React Native Code And Images */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/example/ios/example/AppDelegate.m
+++ b/example/ios/example/AppDelegate.m
@@ -61,7 +61,7 @@ static void InitializeFlipper(UIApplication *application) {
 #if DEBUG
   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
 #else
-  NSURL *url = [[NSBundle mainBundle] URLForResource:@"livebundle" withExtension:@"js"];
+  NSURL *url = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
   return url;
 #endif
 }

--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -10,7 +10,7 @@
 // see also this discussion:
 // https://github.com/brodybits/create-react-native-module/issues/232
 
-const path = require('path')
+const path = require('path');
 
 module.exports = {
   // workaround for an issue with symlinks encountered starting with
@@ -19,12 +19,15 @@ module.exports = {
   resolver: {
     extraNodeModules: new Proxy(
       {},
-      { get: (_, name) => path.resolve('.', 'node_modules', name) }
-    )
-  },
-  transformer: {
-    assetPlugins: ['livebundle-metro-asset-plugin'],
+      {
+        get: (_, name) => {
+          return name === 'react-native-livebundle'
+            ? path.resolve('..')
+            : path.resolve('.', 'node_modules', name);
+        },
+      },
+    ),
   },
   // quick workaround for another issue with symlinks
-  watchFolders: ['.', '..']
-}
+  watchFolders: ['.', '..'],
+};


### PR DESCRIPTION
Fix metro bundling failure on iOS when building release build of the example app.
Building a release build with exo bundle (not connected to packager) is now working properly.