### PR TITLE
remove ssziparchive from example app pod file

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -36,5 +36,3 @@ target 'example-tvOS' do
     # Pods for testing
   end
 end
-pod 'SSZipArchive'
-

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -246,6 +246,7 @@ PODS:
     - React-Core
   - react-native-livebundle (0.0.8):
     - React
+    - SSZipArchive (~> 2.2.3)
   - React-RCTActionSheet (0.63.3):
     - React-Core/RCTActionSheetHeaders (= 0.63.3)
   - React-RCTAnimation (0.63.3):
@@ -360,7 +361,6 @@ DEPENDENCIES:
   - React-RCTText (from `../node_modules/react-native/Libraries/Text`)
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - SSZipArchive
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -465,7 +465,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: b56c03e61c0dd5f5801255f2160a815f4a53d451
   React-jsinspector: 8e68ffbfe23880d3ee9bafa8be2777f60b25cbe2
   react-native-camera: 35854c4f764a4a6cf61c1c3525888b92f0fe4b31
-  react-native-livebundle: 8b68fa80cd948c997b0251ab005d392a6654f2ff
+  react-native-livebundle: 2e209c590b39039cfa562d59592c67c8b0fd47a3
   React-RCTActionSheet: 53ea72699698b0b47a6421cb1c8b4ab215a774aa
   React-RCTAnimation: 1befece0b5183c22ae01b966f5583f42e69a83c2
   React-RCTBlob: 0b284339cbe4b15705a05e2313a51c6d8b51fa40
@@ -480,6 +480,6 @@ SPEC CHECKSUMS:
   Yoga: 7d13633d129fd179e01b8953d38d47be90db185a
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: bc15d73d985e2cbe06c74d22f1a3291feae1cbc1
+PODFILE CHECKSUM: a8be1f7300c9a3073c88b7af646c0e777a69bea0
 
 COCOAPODS: 1.10.0

--- a/react-native-livebundle.podspec
+++ b/react-native-livebundle.podspec
@@ -19,5 +19,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
+  s.dependency "SSZipArchive", "~> 2.2.3"
 end
 


### PR DESCRIPTION
ssziparchive library is used by react-native-livebundle, not the example app.