### PR TITLE
Add host to DeepLink generator config

### DIFF
--- a/LiveBundle.js
+++ b/LiveBundle.js
@@ -97,10 +97,10 @@ export class LiveBundle {
    */
   launchUIFromDeepLink(deepLinkUrl) {
     console.log(`[LiveBundle] launchUIFromDeepLink(${deepLinkUrl})`);
-    if (deepLinkUrl === 'livebundle://menu') {
+    if (/livebundle:\/\/.+\/menu/.test(deepLinkUrl)) {
       return this.launchUI();
     }
-    const reurl = /livebundle:\/\/(sessions|packages)\?id=(.+)/;
+    const reurl = /livebundle:\/\/.+\/(sessions|packages)\?id=(.+)/;
     const capture = reurl.exec(deepLinkUrl);
     if (capture) {
       const [,host, id] = capture;

--- a/example/App.js
+++ b/example/App.js
@@ -10,7 +10,7 @@ export default class App extends Component<{}> {
   render() {
     return (
       <View style={styles.container}>
-        <Text style={styles.welcome}>LiveBundle Demo [Foo]</Text>
+        <Text style={styles.welcome}>LiveBundle Demo</Text>
         <TouchableOpacity
           style={styles.button}
           onPress={() => livebundle.launchUI()}>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -25,9 +25,7 @@
             <action android:name="android.intent.action.VIEW"/>
             <category android:name="android.intent.category.DEFAULT" />
             <category android:name="android.intent.category.BROWSABLE" />
-            <data android:scheme="livebundle" android:host="menu" />
-            <data android:scheme="livebundle" android:host="packages" />
-            <data android:scheme="livebundle" android:host="sessions" />
+            <data android:scheme="livebundle" android:host="io.livebundle.example" />
         </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />

--- a/example/ios/example/Info.plist
+++ b/example/ios/example/Info.plist
@@ -24,7 +24,7 @@
 	<array>
 		<dict>
 			<key>CFBundleURLName</key>
-			<string>io.livebundle</string>
+			<string>io.livebundle.example</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>livebundle</string>

--- a/example/livebundle.yml
+++ b/example/livebundle.yml
@@ -5,9 +5,9 @@ bundler:
       - dev: true
         entry: index.js
         platform: ios
-      - dev: false
+      - dev: true
         entry: index.js
-        platform: ios
+        platform: android
 
 # React Native server
 server:
@@ -22,6 +22,7 @@ storage:
 generators:
   qrcode:
   deeplink:
+    host: io.livebundle.example
 
 # Notifiers
 notifiers:


### PR DESCRIPTION
For example, instead of `livebundle://menu` menu deep link url, the url is now `livebundle://io.livebundle.example/menu` for the example LiveBundle application. This avoid having Android to show a picker for the application in which to open the deep link intent in case multiple applications running LiveBundle are installed on the device.

Corresponding LiveBundle CLI : https://github.com/electrode-io/livebundle/pull/112